### PR TITLE
feat(travis): Semantic release and npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: node_js
+cache:
+  directories:
+    - node_modules
+notifications:
+  email: false
+node_js:
+  - '4'
+before_install:
+  - npm i -g npm@^2.0.0
+before_script:
+  - npm prune
+after_success:
+  - npm run semantic-release
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ cache:
 notifications:
   email: false
 node_js:
-  - '4'
+  - '5.6'
 before_install:
   - npm i -g npm@^2.0.0
 before_script:
   - npm prune
+  - npm run test
 after_success:
-  - npm run semantic-release
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && npm run semantic-release
 branches:
   except:
-    - "/^v\\d+\\.\\d+\\.\\d+$/"
+    - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -20,11 +20,18 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
+    "commitizen": "^2.3.0",
+    "cz-conventional-changelog": "^1.1.5",
     "file-loader": "^0.8.5",
     "glob": "^6.0.4",
     "mocha": "^2.3.4",
     "webpack": "^1.12.11",
     "semantic-release": "^4.3.5"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-asset-manifest",
-  "version": "0.0.4",
+  "version": "0.0.0-semantically-released",
   "description": "Builds asset manifest of assets emitted from webpack.",
   "main": "index.js",
   "keywords": [
@@ -10,7 +10,8 @@
   ],
   "scripts": {
     "test": "mocha ./test",
-    "test-watch": "mocha ./test -w"
+    "test-watch": "mocha ./test -w",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "author": "Hunter Haydel",
   "license": "ISC",
@@ -22,6 +23,11 @@
     "file-loader": "^0.8.5",
     "glob": "^6.0.4",
     "mocha": "^2.3.4",
-    "webpack": "^1.12.11"
+    "webpack": "^1.12.11",
+    "semantic-release": "^4.3.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rentpath/webpack-asset-manifest.git"
   }
 }


### PR DESCRIPTION
Adds `Travis` and `Semantic-release` :dancer: 

Also, should we change this license to `MIT`? 

Addresses #8 
